### PR TITLE
some api changes and an example.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 dist/
 .*.swp
+.virthualenv/*
+.gitignore
+.DS_Store

--- a/examples/callbackPlayer.hs
+++ b/examples/callbackPlayer.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- This is how you would play a song with libsnd and portaudio with Haskell using Callbacks.
+-- Because Haskell is GC, it is not recommended you use callbacks, this is simply for demo purposes
+-- You should use blocking IO instead! Also never test code on with headphones or speakers on loud volume!
+
+import qualified Sound.File.Sndfile as SF
+import qualified Sound.File.Sndfile.Buffer.Vector as VSF
+import qualified Data.Vector.Storable as V
+import System.Environment (getArgs)
+
+import Foreign.C.Types
+import Foreign.Storable
+
+import Sound.PortAudio.Base
+import Sound.PortAudio
+
+import Control.Concurrent
+import Control.Applicative
+
+streamFinished :: String -> IO ()
+streamFinished msg = putStrLn ("Stream Completed: " ++ msg)
+
+simpleCallback :: MVar (V.Vector Float) -> MVar () -> StreamCallback CFloat CFloat
+simpleCallback dataMVar doneMVar _ _ frames _ out = do
+    pnts <- modifyMVar dataMVar (\vec -> let (x, y) = V.splitAt (fromIntegral frames) vec in return (y, x))
+    if (V.null pnts)
+        then (putMVar doneMVar () >> return Complete)
+        else do
+            V.foldM'_ (\i e -> pokeElemOff out i (realToFrac e) >> return (i + 1)) 0 pnts
+            return Continue
+
+
+main :: IO ()
+main = do
+    [inFile] <- getArgs
+    (info, Just (x :: VSF.Buffer Float)) <- SF.readFile inFile
+    
+    let vecData = VSF.fromBuffer x
+    fileData <- newMVar vecData    
+    putStrLn $ "sample rate: " ++ (show $ SF.samplerate info)
+    putStrLn $ "channels: "    ++ (show $ SF.channels info)
+    putStrLn $ "frames: "      ++ (show $ SF.frames info)
+    putStrLn $ "dataLen: "     ++ (show $ V.length vecData)
+
+    result <- withPortAudio $ do
+        withDefaultOutputInfo $ \(out, outInfo) -> do
+            songDone <- newEmptyMVar
+
+            let strmParams = Just $ StreamParameters out (fromIntegral $ SF.channels info) (defaultHighOutputLatency outInfo)
+                smpRate = realToFrac $ SF.samplerate info
+                frmPerBuf = Just $ fromIntegral framesPerBuffer
+                callb = Just $ simpleCallback fileData songDone
+                framesPerBuffer = 2000
+
+
+            withStream Nothing strmParams smpRate frmPerBuf [ClipOff, PrimeOutputBuffers] callb $ \strm -> do
+                s1 <- addStreamFin (makeFinishedCallback $ streamFinished "Finished Playing Song!") strm
+                s2 <- startStream strm
+                takeMVar songDone
+                s3 <- stopStream strm
+                return $ Right ()
+
+    case result of
+        Left err -> print err
+        Right _ -> return ()

--- a/examples/paex_sine.hs
+++ b/examples/paex_sine.hs
@@ -12,9 +12,6 @@ import Text.Printf
 import Foreign.C.Types
 import Foreign.Storable
 
-import System.IO.Unsafe
-import Data.IORef
-
 numSeconds :: Int
 numSeconds = 5
 

--- a/examples/paex_sine.hs
+++ b/examples/paex_sine.hs
@@ -1,0 +1,104 @@
+module Main where
+
+import Sound.PortAudio.Base
+import Sound.PortAudio
+
+import qualified Data.Vector as V
+import Control.Monad (foldM, forM_)
+import Control.Concurrent.MVar
+import Control.Concurrent (threadDelay)
+import Text.Printf
+
+import Foreign.C.Types
+import Foreign.Storable
+
+import System.IO.Unsafe
+import Data.IORef
+
+numSeconds :: Int
+numSeconds = 5
+
+sampRate :: Int
+sampRate = 44100
+
+framesPerBuffer :: Int
+framesPerBuffer = 100
+
+tableSize :: Int
+tableSize = 200
+
+data SineTable = SineTable {
+    sine            :: V.Vector Float,
+    left_phase      :: Int,
+    right_phase     :: Int
+}
+
+newTable :: Int -> SineTable
+newTable sze = SineTable vec 0 0 where
+    intSze = fromInteger $ toInteger sze
+    vec = V.fromList $ map (\i -> sin $ (i / intSze) * pi * 2) [0..(intSze - 1)]
+
+
+-- Recall:
+-- type StreamCallback input output =
+--      Base.PaStreamCallbackTimeInfo -- ^ Timing information for the input and output
+--   -> [StreamCallbackFlag]          -- ^ Status flags
+--   -> CULong                        -- ^ # of input samples
+--   -> Ptr input                     -- ^ input samples
+--   -> Ptr output                    -- ^ where to write output samples
+--   -> IO StreamResult               -- ^ What to do with the stream, plus the output to stream
+--
+
+paTestCallback :: MVar SineTable -> StreamCallback CFloat CFloat
+paTestCallback mvar _ _ frames _ out = do
+    tbl <- readMVar mvar
+
+    let func (l, r) i = do
+        pokeElemOff out (2 * i)      (realToFrac $ (V.!) (sine tbl) l)
+        pokeElemOff out (2 * i + 1)  (realToFrac $ (V.!) (sine tbl) r)
+        let newL = let x = l + 1 in (if x >= tableSize then (x - tableSize) else x)
+        let newR = let x = r + 1 in (if x >= tableSize then (x - tableSize) else x)
+        return (newL, newR)
+
+    (newL', newR') <- foldM func (left_phase tbl, right_phase tbl) [0..(fromIntegral $ frames - 1)]
+        
+    swapMVar mvar (tbl { left_phase = newL', right_phase = newR' })
+    return Continue
+
+streamFinished :: String -> IO ()
+streamFinished msg = putStrLn ("Stream Completed: " ++ msg)
+
+-- Recall:
+-- withStream
+--    :: (StreamFormat input, StreamFormat output) =>
+--       Maybe (StreamParameters input)      -- ^ Input parameters
+--    -> Maybe (StreamParameters output)     -- ^ Output parameters
+--    -> CDouble                             -- ^ Sample rate
+--    -> Maybe CULong                        -- ^ Frames per buffer
+--    -> [StreamOpenFlag]                    -- ^ Stream flags
+--    -> Maybe (StreamCallback input output) -- ^ Callback, or @Nothing@ for a blocking read/write stream
+--    -> (Stream -> IO (Either Error a))     -- ^ Computation to apply
+--    -> IO (Either Error a)
+
+main :: IO ()
+main = do
+    putStrLn $ printf "PortAudio Test: output sine wave. SR = %d, BufSize = %d" sampRate (fromIntegral framesPerBuffer :: Int)
+    result <- withPortAudio $ do
+        withDefaultOutputInfo $ \(out, outInfo) -> do
+            baseTbl <- newMVar (newTable tableSize)
+            
+            let strmParams = (Just $ StreamParameters out 2 (defaultLowOutputLatency outInfo))
+                smpRate = (realToFrac sampRate)
+                frmPerBuf = (Just $ fromIntegral framesPerBuffer)
+                callb = (Just $ paTestCallback baseTbl)
+            
+            withStream Nothing strmParams smpRate frmPerBuf [ClipOff] callb $ \strm -> do
+                s1 <- addStreamFin (makeFinishedCallback $ streamFinished "Sine Wave") strm
+                s2 <- startStream strm
+                threadDelay $ numSeconds * 1000 * 1000
+                s3 <- stopStream strm
+                return $ Right ()
+
+    case result of
+        Left err -> print err
+        Right _ -> return ()

--- a/examples/readme
+++ b/examples/readme
@@ -1,0 +1,1 @@
+Examples

--- a/src/Sound/PortAudio.hs
+++ b/src/Sound/PortAudio.hs
@@ -22,7 +22,7 @@ import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Maybe (fromJust, fromMaybe, isJust)
 import Foreign.C.Types (CDouble, CInt, CFloat, CULong)
-import Foreign.Marshal.Alloc (alloca, free)
+import Foreign.Marshal.Alloc (alloca)
 import Foreign.Ptr (Ptr, castPtr, nullFunPtr, nullPtr, freeHaskellFunPtr)
 import Foreign.Storable (Storable, peek, poke)
 import qualified Sound.PortAudio.Base as Base
@@ -389,7 +389,6 @@ getDeviceInfo x = do
         then return (Left DeviceUnavailable)
         else do
             devStruct <- peek devInfo
---           free devInfo
             return (Right devStruct)
 
 -- If we don't care about user data, just use this

--- a/src/Sound/PortAudio.hs
+++ b/src/Sound/PortAudio.hs
@@ -3,10 +3,11 @@ module Sound.PortAudio
     ( Error(..), errorValuesByCode, errorCodesByValue
     , initialize, terminate, withPortAudio
     , StreamCallback, StreamResult(..)
-    , StreamFormat
+    , StreamFormat, StreamOpenFlag(..)
     , StreamParameters(..)
     , Stream, openStream, withStream, openDefaultStream, withDefaultStream, abortStream, closeStream
-    , startStream, stopStream, withStreamRunning ) where
+    , startStream, stopStream, withStreamRunning
+    , addStreamFin, withDefaultOutputInfo, withDefaultInputInfo, makeFinishedCallback ) where
 
 import Control.Applicative ((<$>))
 import Control.Arrow (first, second, (|||))
@@ -21,7 +22,7 @@ import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Maybe (fromJust, fromMaybe, isJust)
 import Foreign.C.Types (CDouble, CInt, CFloat, CULong)
-import Foreign.Marshal.Alloc (alloca)
+import Foreign.Marshal.Alloc (alloca, free)
 import Foreign.Ptr (Ptr, castPtr, nullFunPtr, nullPtr, freeHaskellFunPtr)
 import Foreign.Storable (Storable, peek, poke)
 import qualified Sound.PortAudio.Base as Base
@@ -117,6 +118,7 @@ initialize = maybeError <$> Base.pa_Initialize
 terminate :: IO (Maybe Error)
 terminate = maybeError <$> Base.pa_Terminate
 
+
 -- | Evaluate a function with PortAudio initialized, terminating it after evaluation
 withPortAudio
     :: IO (Either Error a) -- ^ Computation to apply while PortAudio is initialized
@@ -171,7 +173,6 @@ type StreamCallback input output =
    -> Ptr output                    -- ^ where to write output samples
    -> IO StreamResult               -- ^ What to do with the stream, plus the output to stream
 
- 
 
 -- | Result from stream callbacks that determines the action to take regarding the stream
 data StreamResult
@@ -336,6 +337,65 @@ withDefaultStream numInputs numOutputs sampleRate framesPerBuffer callback =
     bracket open close . (return . Left |||)
         where open = openDefaultStream numInputs numOutputs sampleRate framesPerBuffer callback
               close = const (return Nothing) ||| closeStream
+
+
+
+-- Not sure if these can be replaced in place of the above with Methods.
+-- I think they could still be useful for finer grained control. I'll try to 
+-- write examples where we can't use the above methods in order to demonstrate.
+
+addStreamFin :: Base.PaStreamFinishedCallback -> Stream -> IO (Maybe Error)
+addStreamFin callback strm = do
+    wrapped <- Base.wrap_PaStreamFinishedCallback callback
+    maybeError <$> Base.pa_SetStreamFinishedCallback (underlyingStream strm) wrapped
+
+getDefaultOut :: IO (Either Error Base.PaDeviceIndex)
+getDefaultOut = do
+    out <- Base.PaDeviceIndex <$> Base.pa_GetDefaultOutputDevice
+    return $ if out /= Base.paNoDevice then (Right out) else (Left DeviceUnavailable)
+
+getDefaultIn :: IO (Either Error Base.PaDeviceIndex)
+getDefaultIn = do
+    in_ <- Base.PaDeviceIndex <$> Base.pa_GetDefaultInputDevice
+    return $ if in_ /= Base.paNoDevice then (Right in_) else (Left DeviceUnavailable)
+
+--prolly can simplify with the either monad
+withDefaultOutputInfo :: ((Base.PaDeviceIndex, Base.PaDeviceInfo) -> IO (Either Error a)) -> IO (Either Error a)
+withDefaultOutputInfo func = do
+    out <- getDefaultOut
+    case out of
+        Left err -> return $ Left err
+        Right val -> do
+            outInfo <- getDeviceInfo val
+            case outInfo of
+                Left err2 -> return $ Left err2
+                Right info -> func (val,info)
+
+withDefaultInputInfo :: ((Base.PaDeviceIndex, Base.PaDeviceInfo) -> IO (Either Error a)) -> IO (Either Error a)
+withDefaultInputInfo func = do
+    _in <- getDefaultIn
+    case _in of
+        Left err -> return $ Left err
+        Right val -> do
+            outInfo <- getDeviceInfo val
+            case outInfo of
+                Left err2 -> return $ Left err2
+                Right info -> func (val,info)
+
+getDeviceInfo :: Base.PaDeviceIndex -> IO (Either Error Base.PaDeviceInfo)
+getDeviceInfo x = do
+    devInfo <- Base.pa_GetDeviceInfo (Base.unPaDeviceIndex x)
+    if devInfo == nullPtr
+        then return (Left DeviceUnavailable)
+        else do
+            devStruct <- peek devInfo
+--           free devInfo
+            return (Right devStruct)
+
+-- If we don't care about user data, just use this
+makeFinishedCallback :: IO () -> Base.PaStreamFinishedCallback
+makeFinishedCallback a = \_ -> a
+
 
 -- | Abort audio processing of the stream, stopping output as soon as possible.
 -- Output buffers that haven't already been committed.

--- a/src/Sound/PortAudio/Base.hsc
+++ b/src/Sound/PortAudio/Base.hsc
@@ -46,8 +46,9 @@ type PaStreamCallback =
 type PaStreamCallbackFunPtr = FunPtr PaStreamCallback
 
 type PaStreamFinishedCallback =
-    (  Ptr () -- userData
+    (  Ptr () -> IO ()
     )  
+
 type PaStreamFinishedCallbackFunPtr = FunPtr PaStreamFinishedCallback
 
 {- Other Types -}
@@ -140,11 +141,6 @@ data PaStreamInfo = PaStreamInfo {
     , paBadBufferPtr = paBadBufferPtr 
     }
 
-#{enum PaDeviceIndex, PaDeviceIndex
-    , paNoDevice = paNoDevice
-    , paUseHostApiSpecificDeviceSpecification = paUseHostApiSpecificDeviceSpecification
-    }
-
 #{enum PaHostApiTypeId, PaHostApiTypeId
     , paInDevelopment = paInDevelopment 
     , paDirectSound = paDirectSound 
@@ -160,6 +156,11 @@ data PaStreamInfo = PaStreamInfo {
     , paJACK = paJACK 
     , paWASAPI = paWASAPI 
     , paAudioScienceHPI = paAudioScienceHPI 
+    }
+
+#{enum PaDeviceIndex, PaDeviceIndex
+    , paNoDevice = paNoDevice
+    , paUseHostApiSpecificDeviceSpecification = paUseHostApiSpecificDeviceSpecification
     }
 
 #{enum PaSampleFormat, PaSampleFormat
@@ -195,6 +196,8 @@ data PaStreamInfo = PaStreamInfo {
     , paComplete = paComplete
     , paAbort = paAbort
     }
+
+
 
 {- Other special static values. -}
 paFormatIsSupported :: PaErrorCode
@@ -263,7 +266,7 @@ foreign import ccall unsafe "portaudio.h Pa_GetDefaultOutputDevice"
 
 {- const PaDeviceInfo* Pa_GetDeviceInfo( PaDeviceIndex device ); -}
 foreign import ccall unsafe "portaudio.h Pa_GetDeviceInfo"
-    pa_GetDeviceInfo :: IO (Ptr PaDeviceInfo)
+    pa_GetDeviceInfo :: CInt -> IO (Ptr PaDeviceInfo)
 
 {- PaError Pa_IsFormatSupported( const PaStreamParameters *inputParameters,
                                  const PaStreamParameters *outputParameters,
@@ -319,7 +322,7 @@ foreign import ccall unsafe "portaudio.h Pa_CloseStream"
 {- PaError Pa_SetStreamFinishedCallback( PaStream *stream, PaStreamFinishedCallback* streamFinishedCallback );  -}
 foreign import ccall safe "portaudio.h Pa_SetStreamFinishedCallback"
     pa_SetStreamFinishedCallback :: Ptr PaStream
-                                 -> PaStreamFinishedCallback
+                                 -> PaStreamFinishedCallbackFunPtr
                                  -> IO CInt
 
 {- PaError Pa_StartStream( PaStream *stream ); -}

--- a/src/Sound/PortAudio/Base.hsc
+++ b/src/Sound/PortAudio/Base.hsc
@@ -21,7 +21,7 @@ newtype PaHostApiIndex = PaHostApiIndex { unPaHostApiIndex :: CInt }
 newtype PaHostApiTypeId = PaHostApiTypeId { unPaHostApiTypeId :: CInt }
     deriving (Eq, Show, Storable)
 
-newtype PaSampleFormat = PaSampleFormat { unPaSampleFormat :: CUInt }
+newtype PaSampleFormat = PaSampleFormat { unPaSampleFormat :: CULong }
     deriving (Eq, Show, Storable)
 
 newtype PaStreamFlags = PaStreamFlags { unPaStreamFlags :: CULong }


### PR DESCRIPTION
Hi there! This is a great binding! Thanks for all the hardwork. I just wanted to add some changes, specifically:
1. Fixed Some Types in the hsc file to correspond with http://portaudio.com/docs/v19-doxydocs/portaudio_8h.html,
2. Added a working example
3. Added some additional helper functions to the main api.

The reason for 3 is mostly for usability, but its also important that users have access to latency. For instance, with the same C code, we could run at 64 items per buffer, (try changing line 25 in paex_sine.hs), and you'll realize that the sound is very jaggedy, now increase this number to 2000 and its very smooth. This is a result of the number of frames and line 90 where we specify the latency, with low frame count we can fix the sound by changing that to defaultHighOutputLatency.

The issue I believe is the FFI overhead actually becoming noticeable, but if you have other thoughts please let me know.

I hope to write a few more examples and maybe add some functions to the api to deal with high use cases.

Also, are you considering updating the version on hackage? I really think this version is much simpler and easier to use!
