### PR TITLE
Fixed segmentation fault when closing streams using the blocking interface

### DIFF
--- a/portaudio.cabal
+++ b/portaudio.cabal
@@ -1,5 +1,5 @@
 name: portaudio
-version: 0.2.3
+version: 0.2.3.1
 synopsis: Haskell bindings for the PortAudio library.
 description: Bindings to the cross platform PortAudio library. Version 0.0.1 excludes the callback model.
 category: Sound


### PR DESCRIPTION
It doesn't crash when I use the blocking interface. 

We call pa_CloseStream first before freeing the callbacks.
Otherwise, we may free the callbacks and PortAudio might attempt a callback and we'll crash.
